### PR TITLE
Add curl command to check webserver configuration

### DIFF
--- a/templates/about.html.tera
+++ b/templates/about.html.tera
@@ -21,7 +21,7 @@ User-agent: PrivateBinDirectoryBot
 Disallow: /
 			</pre>
 			<h4>Webserver configuration</h4>
-			<p>If you don't want to rely on this service following your sites <code>robots.txt</code>, you can configure your webserver to block any access that matches this services user agent, which starts with the string <code>PrivateBinDirectoryBot</code>. Here below are examples of configuration snippets to do just that:</p>
+			<p>If you don't want to rely on this service following your sites <code>robots.txt</code>, you can configure your webserver to block any access that matches this services user agent, which <strong>starts with</strong> the string <code>PrivateBinDirectoryBot</code>. Here below are examples of configuration snippets to do just that:</p>
 			<h5>Apache</h5>
 			<pre>
 RewriteEngine On
@@ -38,6 +38,15 @@ respond @privatebinbot 403
 if ($http_user_agent ~ PrivateBinDirectoryBot ) {
 	return 403;
 }
+			</pre>
+			<h5>Check your webserver configuration</h5>
+			<p>The complete user agent string currently looks like this:</p>
+			<pre>
+PrivateBinDirectoryBot/1.2.3 (+https://privatebin.info/directory/about)
+			</pre>
+			<p>You can test your configuration using the following <code>curl</code> command, expecting an HTTP 403 status code:</p>
+			<pre>
+curl -I -H "User-Agent: PrivateBinDirectoryBot/1.2.3 (+https://privatebin.info/directory/about)" https://paste.example.com
 			</pre>
 			<h3 id="faq-how">How the instances are tested</h3>
 			<p>The columns of the lists are based on the following checks:</p>


### PR DESCRIPTION
I followed the advice from Eric Wastl (the creator of Advent of Code) in one of his [conferences](https://youtu.be/CFWuwNDOnIo?t=1120): "For every sentence, there is a user that skipped only that sentence".

So I emphasized the "starts with" in the existing version and added another paragraph later giving the form of the full `User-Agent` string + the curl command we can use to check our webserver configuration.

Closes #19 