### PR TITLE
harden gihub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,12 +4,16 @@ on:
   push:
     tags: '*'
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,12 +3,15 @@ on:
   push:
     branches: '*'
   pull_request:
+permissions: {}
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Install Rust
       run: |
         rustup toolchain install 1.91 --profile minimal --no-self-update


### PR DESCRIPTION
- restrict all default permissions
- content: read is not necessary for public repos
- security-events: write is needed for CodeQL uploads of SARIF reports
- persist-credentials: false prevents any github token to remain configured in the checked out repo (not necessary when not intending to push from the action)
- enable docker & github actions updates in dependabot